### PR TITLE
Bump auguryapi-py to 0.9.69

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ from setuptools import setup
 setup(
     name='nsqworker',
     packages=['nsqworker', 'locker'],
-    version='0.0.28',
+    version='0.0.29',
     install_requires=['tornado==4.5.3', 'pynsq', 'futures; python_version == "2.7"', 'mdict', 'redis',
-                      'auguryapi @ git+https://github.com/augurysys/auguryapi-py.git@0.9.66'],
+                      'auguryapi @ git+https://github.com/augurysys/auguryapi-py.git@0.9.69'],
+
 )


### PR DESCRIPTION
## Summary
- Bumps auguryapi-py dependency from 0.9.66 to 0.9.69
- Bumps nsqworker version to 0.0.29
- Required by event-handler to use the new `detector_config` client in auguryapi-py

## Test plan
- [ ] Verify event-handler builds with nsqworker@0.0.29 + auguryapi-py@0.9.69